### PR TITLE
Not necessary overload

### DIFF
--- a/freqtrade/exchange/bitget.py
+++ b/freqtrade/exchange/bitget.py
@@ -49,14 +49,6 @@ class Bitget(Exchange):
         (TradingMode.FUTURES, MarginMode.ISOLATED)
     ]
 
-    @property
-    def _ccxt_config(self) -> dict:
-        config = {}
-        if self.trading_mode == TradingMode.FUTURES:
-            config.update({"options": {"defaultType": "swap"}})
-        config.update(super()._ccxt_config)
-        return config
-
     @retrier
     def additional_exchange_init(self) -> None:
         try:


### PR DESCRIPTION
## Summary

That's the default from upstream - so this whole property ain't necessary in this subclass

Solve the review change: #11089

## Quick changelog

- Fix requested change

## What's new?

Just requested change to merge
